### PR TITLE
mod(view): layout 설정의 완성. 표준을 지키기 위해 th:utext를 th:replace로 대체함.

### DIFF
--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -146,6 +146,7 @@
         </div>
     </section>
     <script>
+        alert("환영합니다!");
     </script>
 </body>
 </html>

--- a/src/main/resources/templates/layout/layout.html
+++ b/src/main/resources/templates/layout/layout.html
@@ -19,6 +19,6 @@
     <th:block th:replace="~{layout/footer :: footer}"></th:block>
 
     <script th:src="@{https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js}"></script>
-    <th:block th:replace="${script}"></th:block>
+    <th:block th:replace="${script} ?: ~{}"></th:block>
 </body>
 </html>


### PR DESCRIPTION
replace시에 특정 매개변수의 값이 존재하지 않는 경우라도 ${script} ?: ~{} 를 통해 없으면 빈 조각을 출력해라로 해결. 그래서 일관되게 th:replace를 사용하게 해둠.