### PR TITLE
coeat 컨트롤러와 서비스에서 메서드, 추상메서드 추가 및 내용 작성.

### DIFF
--- a/src/main/java/com/jslhrd/yorimichi/controller/CoeatController.java
+++ b/src/main/java/com/jslhrd/yorimichi/controller/CoeatController.java
@@ -3,77 +3,76 @@ package com.jslhrd.yorimichi.controller;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.jslhrd.yorimichi.domain.CoeatDTO;
+import com.jslhrd.yorimichi.domain.CoeatRequestDTO;
 import com.jslhrd.yorimichi.service.CoeatService;
 
 import lombok.RequiredArgsConstructor;
 
+import java.security.Principal;
+import java.util.List;
+
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.PutMapping;
-
-
-
-
-
 @RestController
 @RequiredArgsConstructor
 public class CoeatController {
 	
-	//private final CoeatService coeatService;
+	private final CoeatService coeatService;
+
+	//같이먹기 리스트
+	@GetMapping("/coeats")
+	public List<CoeatDTO> showCoeatList(){
+		 return coeatService.getCoeatList();
+	}
 
 	//같이먹기 상세
+	//	"/coeat/{id}"
 	@GetMapping("/coeat/{id}")
-	public void showCoeat() {
-		//return CoeatDTO coeat;
-		//같이먹기 상세 조회 메서드도 없는 것 같습니다.
+	public CoeatDTO showCoeat(@PathVariable("id") Long feedId) {
+		return coeatService.getCoeatDetail(feedId);
 	}
 
-	@GetMapping("/coeats")
-	public void showCoeatList(){
-		//아이디 없이 최신 같이먹기를 불러올 수 있는 메서드가 있으면 좋겠습니다
-		//List<CoeatDTO> coeats = CoeatService.???();
-		//return coeats;
+	//같이먹기 삭제
+	@DeleteMapping("/coeat/{id}")
+	public void deleteCoeat(@PathVariable("id") Long feedId){
+		coeatService.deleteCoeat(feedId);
 	}
 
-	
 	//같이먹기 작성
 	@PostMapping("/coeat")
 	public void postCoeat(@RequestBody CoeatDTO coeat) {
-		//return List<CoeatDTO> coeats;
+		coeatService.save(coeat);
 	}
 	
 	//같이먹기 수정
 	@PutMapping("/coeat")
 	public void putCoeat(@RequestBody CoeatDTO coeat) {
+		coeatService.updateCoeat(coeat);
 	}
 
-	//같이먹기 삭제
-	@DeleteMapping("/coeat")
-	public void deleteCoeat(@RequestBody Long id){
-		//return List<CoeatDTO> coeats;
-	}
-	
 	//같이먹기 신청
 	@PostMapping("/coeat/participant")
-	public void participateCoeat(@RequestBody Long coeatId) {
-		//return List<CoeatRequestDTO> participants;
+	public void participateCoeat(@RequestBody CoeatDTO coeat,Principal principal) {
+		coeatService.joinCoeat(null, null);
+		//TODO: 현재 userId를 알아낼 방법이 없습니다.
 	}
 	
 	//같이먹기 수락
 	//대기 상태에서 수락상태로 변경하는 거로 처리될 것 같아요
 	@PatchMapping("/coeat/participant")
-	public void acceptParticipant(@RequestBody Long UserId){
-		//return List<CoeatRequestDTO> participants;
+	public void acceptParticipant(@RequestBody CoeatRequestDTO coeatRequest, Principal principal){
+		coeatService.acceptParticipant(principal, coeatRequest);
 	}
 
-	//같이먹기 제외/거절
-	//명단에서 제거하는 건데, 상태 변경 없이 삭제로 다 될 것 같아요
+	//같이먹기 제외/거절/취소
 	@DeleteMapping("/coeat/participant")
-	public void deleteParticipant(@RequestBody Long UserId){
-		//return List<CoeatRequestDTO> participants;
+	public void deleteParticipant(@RequestBody CoeatRequestDTO coeatRequest, Principal principal){
+		coeatService.rejectParticipant(principal, coeatRequest);
 	}
 	
 

--- a/src/main/java/com/jslhrd/yorimichi/service/CoeatService.java
+++ b/src/main/java/com/jslhrd/yorimichi/service/CoeatService.java
@@ -1,5 +1,11 @@
 package com.jslhrd.yorimichi.service;
 
+import java.security.Principal;
+import java.util.List;
+
+import com.jslhrd.yorimichi.domain.CoeatDTO;
+import com.jslhrd.yorimichi.domain.CoeatRequestDTO;
+
 /**
  * 같이먹기 서비스 인터페이스입니다.
  * 
@@ -34,4 +40,37 @@ public interface CoeatService {
 	 * @param FeedId
 	 */
 	public void joinCoeat(Long userId, Long feedId);
+
+	/**
+	 * CoeatRequest에 있는 신청자가 Coeat리스트 안으로 들어가고, CoeatRequest에서는 삭제됩니다.
+	 * TODO: 컨트롤러를 작성하며 임시로 작성해둔 서비스 검토 필요
+	 * principal은 작성자가 맞는지 확인용
+	 * @param principal
+	 * @param coeatRequest
+	 */
+	public void acceptParticipant(Principal principal, CoeatRequestDTO coeatRequest);
+
+	/**
+	 * CoeatRequest에 있는 신청자가 CoeatRequest에서는 삭제됩니다.
+	 * TODO: 컨트롤러를 작성하며 임시로 작성해둔 서비스 검토 필요
+	 * principal은 작성자가 맞는지 확인용
+	 * @param principal
+	 * @param coeatRequest
+	 */
+	public void rejectParticipant(Principal principal, CoeatRequestDTO coeatRequest);
+
+	/**
+	 * feedId를 통해 같이먹기 상세정보를 반환합니다.
+	 * TODO: 컨트롤러를 작성하며 임시로 작성해둔 서비스 검토 필요
+	 * @param feedId
+	 * @return CoeatDTO
+	 */
+	public CoeatDTO getCoeatDetail(Long feedId);
+
+	/**
+	 * 같이먹기 리스트를 반환합니다.
+	 * TODO: 컨트롤러를 작성하며 임시로 작성해둔 서비스 검토 필요
+	 * @return List<CoeatDTO>
+	 */
+	public List<CoeatDTO> getCoeatList();
 }


### PR DESCRIPTION
문제점
현재 userId를 알아낼 방법이 없습니다.

의문점
controller에서 요청시 받아온 객체 데이터에서 객체 내부의 변수를 꺼내고, Principal 객체에서 username을 알아내서 그걸 userservice로 보내서 userId를 가져와서 다시 다른 Service로 보내는 작업을 하는 게 이상한 것 같습니다.
물론 하면 안 되는 건 아닌데, 서비스나 DTO에서 변경이 발생하면 컨트롤러도 세세하게 바꿔야 하기 때문에 문제가 될 것 같습니다.

이하 작업목록

서비스에서의 작업
- 같이먹기 리스트 조회,
- 같이먹기 단일 조회,
- 같이먹기 수락,
- 같이먹기 제외/거절/취소
서비스를 임시로 작성했습니다. 검토 바랍니다.

컨트롤러에서의 작업
- 각 메서드와 서비스를 연결.
- parthvariable과 requestBody로 받는 것의 구분.

