### PR TITLE
fix(dataSource): 데이터베이스 패스워드 관련 개선

### DIFF
--- a/src/main/java/com/jslhrd/yorimichi/YorimichiApplication.java
+++ b/src/main/java/com/jslhrd/yorimichi/YorimichiApplication.java
@@ -1,13 +1,56 @@
 package com.jslhrd.yorimichi;
 
+import java.io.Console;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class YorimichiApplication {
 
+	private static final String DB_PASSWORD = "DB_PASSWORD";
+
 	public static void main(String[] args) {
+		initializeDatabasePassword();
 		SpringApplication.run(YorimichiApplication.class, args);
 	}
 
+	/**
+	 * <h1>데이터베이스 비밀번호 초기화 함수</h1>
+	 * yml에서 개인 브랜치마다 바꾸고 해당 파일 커밋 조심하고 하던 시대는 끝났습니다.
+	 * <p>이제 서버 킬 때 입력하세요!
+	 * <p>또는 환경변수 DB_PASSWORD에 미리 정의하세요!
+	 * <p>해당 함수로 당신의 개발환경의 질을 향상시키세요!
+	 */
+	private static void initializeDatabasePassword() {
+		String pwd = System.getenv(DB_PASSWORD);
+		
+		if (pwd == null || pwd.isEmpty()) {
+			pwd = System.getProperty(DB_PASSWORD);
+		}
+
+		if (pwd == null || pwd.isEmpty()) {
+			Console console = System.console();
+			if (console != null) {
+				char[] passChars = console.readPassword("Enter DB password: ");
+
+				if (passChars != null) {
+					pwd = new String(passChars);
+					System.setProperty(DB_PASSWORD, pwd);
+				}
+			} else {
+				try {
+					System.out.println("Enter DB password (stdin): ");
+					byte[] input = new byte[256];
+					int r = System.in.read(input);
+					if (r > 0) {
+						pwd = new String(input, 0, r).trim();
+						System.setProperty(DB_PASSWORD, pwd);
+					}
+				} catch (Exception e) {
+					
+				}
+			}
+		}
+	}
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -19,7 +19,7 @@ spring:
 
 # mysql에서 db와 서버의 시간이 다른 경우 문제가 발생할 수 있어서 시간대를 명시하게 함.
     username: jsl3team
-    password: jslhrd79 #[701 wi-fi password]
+    password: ${DB_PASSWORD:} #[701 wi-fi password]
 
 # Thymeleaf 설정
 # 캐시를 저장하지 않게 해둬서 변경시 바로바로 확인 가능


### PR DESCRIPTION
# 데이터베이스 비밀번호 관리가 개선되었습니다.
yml 에서 개인 브랜치마다 db.password 값을 바꾸고 해당 파일의 커밋을 조심하는 시대는 끝났습니다.  
이제 서버를 켤 때 입력하세요!  
또는 본인 운영체제의 환경변수 DB_PASSWORD에 미리 정의하세요!
해당 함수로 당신의 개발환경의 질을 향상시키세요!  
- 환경변수가 있다면 우선 적용됩니다.
- 환경변수가 없다면 서버를 동작할 경우 입력을 요구합니다.

### 입력창 예시
<img width="659" height="112" alt="image" src="https://github.com/user-attachments/assets/2376094e-7192-4160-a1a7-990615a283ae" />


# Windows 환경 변수 설정 방법

## 1. 시스템 환경 변수 열기
1. **Windows 검색창**에 `환경 변수` 입력  
2. **"시스템 환경 변수 편집"** 클릭  
3. **"환경 변수(N)..."** 버튼 클릭  

## 2. 사용자 / 시스템 변수 구분
- **사용자 변수**: 현재 로그인한 사용자에게만 적용  
- **시스템 변수**: 모든 사용자에게 적용  

## 3. 새 변수 추가
1. **새로 만들기(N)** 클릭  
2. 변수 이름과 변수 값을 입력  
3. 확인(OK)  

## 4. 기존 변수 수정
1. 수정할 변수 선택  
2. **편집(E)** 클릭  
3. 값 변경 후 확인  

## 5. 적용 확인
1. **명령 프롬프트(cmd)** 열기  
2. 다음 명령 입력  
   ```cmd
   echo %변수이름%

# 맥, 리눅스 환경설정 방법

## 사용하는 쉘 확인 후 설정
- Bash: vim(vi 또는 nano) ~/.bashrc
- Zsh: vim(vi 또는 nano) ~/.zshrc

## 쉘 내부에 해당 값 추가
```bash
export DB_PASSWORD=[비밀번호]
```
- vim,vi는 i(insert)를 눌러 편집모드로 들어간 후 작성합니다.    
- 작성이 완료되면 :wq(write, quit)를 눌러 저장 후 빠져나옵니다.  

## vim 에서 저장 후 밖으로 이동,적용 및 확인
```bash
# 적용하기
source ~/.bashrc(~/.zshrc)
# 확인하기
echo $DB_PASSWORD
```

>[!WARNING]
IDE 를 꼭 껐다가 켜세요 찡찡대시면 안 됩니다. 